### PR TITLE
Add config setting to increase polyhedra dimensions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,23 +308,23 @@
           <input
             type="button"
             value="-"
-            onclick="updateExtraDims(document.getElementById('xsz'), -1)"
+            onclick="updateSizeOffset(document.getElementById('soff'), -1)"
           />
           <input
             autocomplete="off"
             type="textbox"
             value="0"
-            id="xsz"
-            name="xsz"
+            id="soff"
+            name="soff"
             size="1"
-            onblur="updateExtraDims(this, 0)"
+            onblur="updateSizeOffset(this, 0)"
           />
           <input
             type="button"
             value="+"
-            onclick="updateExtraDims(document.getElementById('xsz'), 1)"
+            onclick="updateSizeOffset(document.getElementById('soff'), 1)"
           />
-          <label>Extra dimensions</label>
+          <label>Size Offset</label>
 
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -136,27 +136,27 @@
       <ul style="margin-right: 10px;">
         <li style="text-align: left; margin-bottom: 10px;">
           To twist a slice,
-          <br/>press (left-mouse-button OR touch-screen) over a sticker & drag.
+          <br/>press (left-mouse-button OR touch-screen) over a sticker &amp; drag.
         </li>
         <li style="text-align: left; margin-bottom: 10px;">
           To rotate the puzzle,
-          <br/>press (left-mouse-button OR touch-screen) on the empty-space near the puzzle & drag.
+          <br/>press (left-mouse-button OR touch-screen) on the empty-space near the puzzle &amp; drag.
           <br/><br/>Alternatively (on PC),
-          <br/>press (right-bouse-button OR ctrl+left-mouse-button) anywhere on puzzle canvas & drag.
+          <br/>press (right-bouse-button OR ctrl+left-mouse-button) anywhere on puzzle canvas &amp; drag.
         </li>
         <li style="text-align: left; margin-bottom: 10px;">
-          Click on any puzzle in the menu to select it & Trigger automatic
+          Click on any puzzle in the menu to select it &amp; Trigger automatic
           scramble using the play button.
         </li>
         <li style="text-align: left; margin-bottom: 10px;">
           You can use the solve button to auto-generate solutions for differnt puzzles to learn from.
         </li>
         <li style="text-align: left; margin-bottom: 10px;">
-          Before a given puzzle state can be solved by the algorithm, preprocessing must be done for the shape & size. The preprocessed data stays in memory till the tab is killed, so subsequent solves are much faster than the first one.
+          Before a given puzzle state can be solved by the algorithm, preprocessing must be done for the shape &amp; size. The preprocessed data stays in memory till the tab is killed, so subsequent solves are much faster than the first one.
         </li>
         <li style="text-align: left; margin-bottom: 10px;">
-          The interface has an advanced feature to point & swap stickers.
-          This can be helpful to analyze differnt positions & how the solver tackels them.
+          The interface has an advanced feature to point &amp; swap stickers.
+          This can be helpful to analyze different positions &amp; how the solver tackles them.
           Note that it is very easy to bring the puzzle to unsolvable states by using this feature. The automated solver will do best effort fixing of such states.
         </li>
       </ul>
@@ -302,7 +302,30 @@
             name="pns"
             onclick="window.pointAndSwap=!window.pointAndSwap; window.tempS = undefined;"
           />
-          <label for="pns">Point & Swap mode</label>
+          <label for="pns">Point &amp; Swap mode</label>
+          <br />
+
+          <input
+            type="button"
+            value="-"
+            onclick="updateExtraDims(document.getElementById('xsz'), -1)"
+          />
+          <input
+            autocomplete="off"
+            type="textbox"
+            value="0"
+            id="xsz"
+            name="xsz"
+            size="1"
+            onblur="updateExtraDims(this, 0)"
+          />
+          <input
+            type="button"
+            value="+"
+            onclick="updateExtraDims(document.getElementById('xsz'), 1)"
+          />
+          <label>Extra dimensions</label>
+
         </div>
       </div>
       <div style="margin: 50px 65px; height: 35px; font-size: 40px;">

--- a/src/menu.js
+++ b/src/menu.js
@@ -19,11 +19,31 @@
       dodecahedron: [1, 2, 3],
       icosahedron: [2, 3, 4],
     },
+    baseSizes: {
+      tetrahedron: [3, 4, 5],
+      cube: [2, 3, 4],
+      octahedron: [2, 3, 4],
+      dodecahedron: [1, 2, 3],
+      icosahedron: [2, 3, 4],
+    },
+    extraDims: 0,
   };
 
   let menuStateCounter = 0;
 
+  window.updateExtraDims = (elem, count) => {
+    const val = Math.max((parseInt(elem.value) || 0) + count, 0);
+    elem.value = val;
+    window.menuConfig.extraDims = val;
+  }
+
   window.showShapeMenu = () => {
+
+    // Update sizes.
+    for (const [key, ary] of Object.entries(window.menuConfig.baseSizes)) {
+      window.menuConfig.sizes[key] = ary.map(val => val + window.menuConfig.extraDims);
+    }
+
     menuStateCounter++;
     window.puzzlemenu.style.display = window.shapemenu.style.display = window.settingsmenubutton.style.display =
       "inline-block";

--- a/src/menu.js
+++ b/src/menu.js
@@ -12,13 +12,6 @@
       icosahedron: (size, isDemo) =>
         new Icosahedron(size, isDemo ? 42.5 : undefined),
     },
-    sizes: {
-      tetrahedron: [3, 4, 5],
-      cube: [2, 3, 4],
-      octahedron: [2, 3, 4],
-      dodecahedron: [1, 2, 3],
-      icosahedron: [2, 3, 4],
-    },
     baseSizes: {
       tetrahedron: [3, 4, 5],
       cube: [2, 3, 4],
@@ -26,12 +19,12 @@
       dodecahedron: [1, 2, 3],
       icosahedron: [2, 3, 4],
     },
-    extraDims: 0,
+    sizeOffset: 0,
   };
 
   let menuStateCounter = 0;
 
-  window.updateExtraDims = (elem, count) => {
+  window.updateSizeOffset = (elem, count) => {
     const val = Math.max((parseInt(elem.value) || 0) + count, 0);
     elem.value = val;
     window.menuConfig.extraDims = val;
@@ -39,7 +32,8 @@
 
   window.showShapeMenu = () => {
 
-    // Update sizes.
+    // Create sizes.
+    window.menuConfig.sizes = [];
     for (const [key, ary] of Object.entries(window.menuConfig.baseSizes)) {
       window.menuConfig.sizes[key] = ary.map(val => val + window.menuConfig.extraDims);
     }


### PR DESCRIPTION
This PR adds a config setting to allow working with higher-order polyhedra.

Prior to this PR, the maximum (e.g.) cube-order was 4; this PR allows a cube-order of any size. However, the PR has the following caveats:

    Only three orders of a polyhedra are shown. e.g. The UI displays three cubes with orders [2, 3, 4]. Increasing the 'Extra dimensions' setting to 3 would display three cubes with orders [5, 6, 7].

    The config setting affects all polyhedra. e.g. It is not possible to simultaneously have a cube size of order-3 and a tetrahedron size of order-8.

    High-order polyhedra can be tricky to manipulate in the UI.

    The solver may take too long (or, perhaps, may not work?) on larger polyhedra. I gave up waiting for the solver to finish a 6x6x6 cube.

This PR also properly encodes '&' characters as '&'.

If you are not interested in this pull request, please feel free to close/reject it.
