### PR TITLE
Alert user if Worker fails.

### DIFF
--- a/src/solver.js
+++ b/src/solver.js
@@ -1,10 +1,16 @@
 (() => {
+
+  window.showSolverUnsupportedMessage = () => {
+      window.solverunsupported.style.display = "block";
+      window.solvewrapper.style.display = "none";
+  };
+
   // The interface from the UI thread to the solver worker.
   if (window.Worker) {
     window.solverWorker = new Worker("src/solver-worker.js");
+    window.solverWorker.onerror = ((evt) => showSolverUnsupportedMessage());
   } else {
-    window.solverunsupported.style.display = "block";
-    window.solvewrapper.style.display = "none";
+    showSolverUnsupportedMessage();
   }
 
   // Generated solution can be traverses using 2 stacks.


### PR DESCRIPTION
Worker failure can occur (due to Security Error) when `index.html` is loaded from the file system rather than a web server.

Per your request in PR #10, I've wrapped the two lines in a small function for re-use. This causes the same message to be displayed both when `Worker` is not supported by the browser and when `Worker` is supported, but fails.

If you want the wording of the displayed message to be changed (or to have two different messages), please let me know and I'll be glad to update.